### PR TITLE
Make outputFile optional and return contributions from call, create outputFile if non-existent

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ First install the package from npm:
 npm install volunteer-contribution-fetch
 ```
 
-Then you can create a file in your project which runs the fetch operation and provides the necesary config:
+Then you can create a file in your project which runs the fetch operation and provides the necessary config:
 
 ```js
 const { fetchAll } = require('volunteer-contributions-fetch');
@@ -59,6 +59,22 @@ const config = {}; // See below for documentation and a sample config
 
 fetchAll(config);
 ```
+
+### Usage without output file
+
+This can also be used without having to rely on an `outputFile`. For this case the `fetchAll` function returns all contributions. Additionally you can also pass existing contributions to the function and these will be considered as well. The return value and the parameter of the function works the same as having an `outputFile`.
+
+```js
+const { fetchAll } = require('volunteer-contributions-fetch');
+
+const config = {}; // See below for documentation and a sample config
+const existingContributions = [{ ... }];
+
+const results = fetchAll(config, existingContributions);
+// results is now all existing contributions plus any newly fetched contribution
+```
+
+Note that passing existing contributions this way will be ignored if a `outputFile` is used.
 
 ## Configuration
 
@@ -76,14 +92,14 @@ This section documents all the possible configuration values. For examples see t
 
 #### General
 
-| Field             | Data Type | Required | Default | Description                                        |
-| ----------------- | --------- | -------- | ------- | -------------------------------------------------- |
-| `outputFile`      | string    | Yes      | -       | Path to contributions output file                  |
-| `bugzilla`        | Object    | No       | -       | Bugzilla configuration options (see below)         |
-| `communityPortal` | Object    | No       | -       | Community Portal configuration options (see below) |
-| `discourse`       | Object    | No       | -       | Discourse configuration options (see below)        |
-| `github`          | Object    | No       | -       | GitHub configuration options (see below)           |
-| `mediaWiki`       | Object    | No       | -       | MediaWiki configuration options (see below)        |
+| Field             | Data Type | Required | Default | Description                                                                                                        |
+| ----------------- | --------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `outputFile`      | string    | No       | -       | Path to contributions output file. Contributions are read from this file and new contributions will be added here. |
+| `bugzilla`        | Object    | No       | -       | Bugzilla configuration options (see below)                                                                         |
+| `communityPortal` | Object    | No       | -       | Community Portal configuration options (see below)                                                                 |
+| `discourse`       | Object    | No       | -       | Discourse configuration options (see below)                                                                        |
+| `github`          | Object    | No       | -       | GitHub configuration options (see below)                                                                           |
+| `mediaWiki`       | Object    | No       | -       | MediaWiki configuration options (see below)                                                                        |
 
 #### Bugzilla
 

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -11,11 +11,21 @@ const wiki = require('./wiki');
 async function fetchAll(config) {
   validateConfig(config);
 
-  debug('fetching...');
-  const existingContributions = JSON.parse(
-    await fs.readFile(config.outputFile)
-  );
+  let existingContributions = [];
+  if (config.outputFile) {
+    debug('checking output file...');
+    try {
+      await fs.stat(config.outputFile);
+      existingContributions = JSON.parse(await fs.readFile(config.outputFile));
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        debug('output file does not exist, creating!');
+        await fs.writeFile(config.outputFile, JSON.stringify([]));
+      }
+    }
+  }
 
+  debug('fetching...');
   const bugzillaResult = await bugzilla.gather(config, existingContributions);
   const githubResult = await github.gather(config, existingContributions);
   const wikiResult = await wiki.gather(config);

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -8,14 +8,16 @@ const github = require('./github');
 const { validateConfig } = require('./validator');
 const wiki = require('./wiki');
 
-async function fetchAll(config) {
+async function fetchAll(config, contributions = []) {
   validateConfig(config);
 
-  let existingContributions = [];
+  let existingContributions = contributions;
   if (config.outputFile) {
     debug('checking output file...');
     try {
       await fs.stat(config.outputFile);
+      // Passing existing contributions through the parameter is overwritten
+      // if an outputFile exists.
       existingContributions = JSON.parse(await fs.readFile(config.outputFile));
     } catch (error) {
       if (error.code === 'ENOENT') {
@@ -71,17 +73,22 @@ async function fetchAll(config) {
 
   if (uniqueContributions.length === existingContributions.length) {
     debug('NO_UPDATE_ABORTING');
-    return;
+    return uniqueContributions;
   }
 
   uniqueContributions.sort(
     (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
   );
-  await fs.writeFile(
-    config.outputFile,
-    `${JSON.stringify(uniqueContributions, null, 2)}\n`
-  );
-  debug('FILE_WRITTEN');
+
+  if (config.outputFile) {
+    await fs.writeFile(
+      config.outputFile,
+      `${JSON.stringify(uniqueContributions, null, 2)}\n`
+    );
+    debug('FILE_WRITTEN');
+  }
+
+  return uniqueContributions;
 }
 
 module.exports = {

--- a/lib/fetch.test.js
+++ b/lib/fetch.test.js
@@ -21,6 +21,7 @@ test.beforeEach((t) => {
   // eslint-disable-next-line no-param-reassign
   t.context.sandbox.originalJSONParse = JSON.parse;
   t.context.sandbox.stub(fs, 'readFile').resolves('');
+  t.context.sandbox.stub(fs, 'stat').resolves('');
   t.context.sandbox.stub(fs, 'writeFile').resolves('');
   t.context.sandbox.stub(JSON, 'parse').returns([]);
   t.context.sandbox.stub(validator, 'validateConfig').returns([]);
@@ -33,6 +34,19 @@ test.beforeEach((t) => {
 test.afterEach.always((t) => {
   t.context.sandbox.restore();
 });
+
+test.serial(
+  'should create a contributions file if file does not exist',
+  async (t) => {
+    const error = new Error('oh no, no config file!');
+    error.code = 'ENOENT';
+    fs.stat.throws(error);
+    await fetch.fetchAll(config);
+    t.is(fs.writeFile.callCount, 1);
+    t.is(fs.writeFile.getCall(0).args[0], config.outputFile);
+    t.is(fs.writeFile.getCall(0).args[1], '[]');
+  }
+);
 
 test.serial('should not write file if there was nothing to do', async (t) => {
   const result = await fetch.fetchAll(config);

--- a/lib/fetch.test.js
+++ b/lib/fetch.test.js
@@ -49,8 +49,7 @@ test.serial(
 );
 
 test.serial('should not write file if there was nothing to do', async (t) => {
-  const result = await fetch.fetchAll(config);
-  t.is(result, undefined);
+  await fetch.fetchAll(config);
   t.is(fs.writeFile.callCount, 0);
 });
 
@@ -100,4 +99,24 @@ test.serial('should take all return values', async (t) => {
     t.context.sandbox.originalJSONParse(fs.writeFile.getCall(0).args[1]).length,
     4
   );
+});
+
+test.serial('should return contributions', async (t) => {
+  const contributions = [{ source: 'community-portal' }];
+  communityPortal.gather.returns(contributions);
+
+  const result = await fetch.fetchAll(config);
+  t.deepEqual(result, contributions);
+});
+
+test.serial('should consider passed contributions', async (t) => {
+  const contributions = [{ source: 'community-portal' }];
+  communityPortal.gather.returns(contributions);
+  const existingContributions = [
+    { source: 'existing' },
+    { source: 'existing' },
+  ];
+
+  const result = await fetch.fetchAll({}, existingContributions);
+  t.deepEqual(result, [...existingContributions, ...contributions]);
 });

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -15,10 +15,6 @@ function validateConfig(config) {
     throw new Error('No config passed!');
   }
 
-  if (!config.outputFile) {
-    throw new Error('outputFile is required');
-  }
-
   validateCommunityPortal(config.communityPortal);
   validateDiscourse(config.discourse);
   validateWiki(config.mediaWiki);

--- a/lib/validator.test.js
+++ b/lib/validator.test.js
@@ -34,10 +34,6 @@ test.serial('should throw when missing config', (t) => {
   t.throws(() => validator.validateConfig());
 });
 
-test.serial('should throw when outputFile is not defined', (t) => {
-  t.throws(() => validator.validateConfig({ somethingElse: true }));
-});
-
 test.serial('should throw when community portal validation fails', (t) => {
   communityPortal.validate.rejects(new Error('oh no'));
   t.throws(() => validator.validateConfig());


### PR DESCRIPTION
As reported in #10 there is a bug when the `outputFile` does not yet exist. This PR automatically creates the file in this case. Additionally the `fetchAll` function now returns the same contributions as are written to the file. And you can now also pass existing contributions to the function. This allows the usage without an `outputFile`.